### PR TITLE
Set the HTTP status code in AJAX responses

### DIFF
--- a/src/erdiko/core/AjaxController.php
+++ b/src/erdiko/core/AjaxController.php
@@ -7,7 +7,9 @@
  * @category   Erdiko
  * @package    Core
  * @copyright  Copyright (c) 2014, Arroyo Labs, http://www.arroyolabs.com
- * @author	   John Arroyo
+ *
+ * @author	   John Arroyo john@arroyolabs.com
+ * @author	   Andy Armstrong andy@arroyolabs.com
  */
 namespace erdiko\core;
 use Erdiko;
@@ -17,12 +19,25 @@ use Erdiko;
  */
 class AjaxController extends Controller 
 {
-	/**
- 	 * Contructor
- 	 */
-	public function __construct()
-	{
-		$this->_webroot = ROOT;
-		$this->_response = new \erdiko\core\AjaxResponse;
+
+  /**
+   * Contructor
+   */
+  public function __construct()
+  {
+    $this->_webroot = ROOT;
+    $this->_response = new \erdiko\core\AjaxResponse;
+  }
+
+  /**
+   * setStatusCode
+   *
+   */
+  public function setStatusCode($code = null) 
+  {
+    if(!empty($code)) {
+      $this->_response->setStatusCode($code);
     }
+  }
+
 }

--- a/src/erdiko/core/AjaxController.php
+++ b/src/erdiko/core/AjaxController.php
@@ -40,4 +40,10 @@ class AjaxController extends Controller
     }
   }
 
+  public function setErrors($errors = null)
+  {
+    if(!empty($errors)) {
+      $this->_response->setErrors($errors);
+    }
+  }
 }

--- a/src/erdiko/core/AjaxResponse.php
+++ b/src/erdiko/core/AjaxResponse.php
@@ -27,6 +27,13 @@ class AjaxResponse extends Response
     protected $_statusCode = 200;
 
     /**
+     * _errors 
+     *
+     *
+     */
+    protected $_errors = false;
+
+    /**
      * Theme
      */
     protected $_theme;
@@ -48,6 +55,18 @@ class AjaxResponse extends Response
       }
     }
 
+    public function setErrors($errors = null) 
+    {
+      if(!empty($errors)) {
+
+        if(!is_array($errors)) {
+          $errors = array($errors);
+        }
+
+        $this->_errors = $errors;
+      }
+    }
+
     /**
      * Ajax render function
      *
@@ -57,8 +76,8 @@ class AjaxResponse extends Response
     {
       $responseData = array(
                               "status" => $this->_statusCode,
-                              "body" => $this->_content,
-                              "errors" => array()
+                              "body"   => $this->_content,
+                              "errors" => $this->_errors
                             );
 
       return json_encode($responseData);

--- a/src/erdiko/core/AjaxResponse.php
+++ b/src/erdiko/core/AjaxResponse.php
@@ -5,7 +5,9 @@
  * @category   Erdiko
  * @package    Core
  * @copyright  Copyright (c) 2014, Arroyo Labs, http://www.arroyolabs.com
- * @author	   John Arroyo
+ * 
+ * @author	   John Arroyo john@arroyolabs.com
+ * @author	   Andy Armstrong andy@arroyolabs.com
  */
 namespace erdiko\core;
 use Erdiko;
@@ -15,14 +17,36 @@ use Erdiko;
  */
 class AjaxResponse extends Response 
 {
+
+    /**
+     * _statusCode
+     *
+     * Unless explicitly set, default to a 200 status 
+     * assuming everything went ok.
+     */
+    protected $_statusCode = 200;
+
     /**
      * Theme
      */
-	protected $_theme;
+    protected $_theme;
+
     /**
      * Content
      */
-	protected $_content = null;
+    protected $_content = null;
+
+    /**
+     * setStatusCode
+     * 
+     * Set, and send, the HTTP status code. 
+     */
+    public function setStatusCode($code = null) {
+      if(!empty($code)) {
+        $this->_statusCode = $code;
+        http_response_code($this->_statusCode); // this sends the http status code
+      }
+    }
 
     /**
      * Ajax render function
@@ -31,13 +55,13 @@ class AjaxResponse extends Response
      */
     public function render()
     {
-        $responseData = array(
-            "status" => 500,
-            "body" => $this->_content,
-            "errors" => array()
-            );
+      $responseData = array(
+                              "status" => $this->_statusCode,
+                              "body" => $this->_content,
+                              "errors" => array()
+                            );
 
-        return json_encode($responseData);
+      return json_encode($responseData);
     }
 
 }


### PR DESCRIPTION
Actually return the HTTP status with the header response, and include it in the AJAX response for debugging.