### PR TITLE
ER-64: Fix CacheTest

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -28,7 +28,7 @@ class Cache
     {
             //Check if the caller requests an new object
         if (empty(self::$instance[$cacheConfig])) {
-            $config = Helper::getConfig();
+            $config = Helper::getConfig('application', $cacheConfig);
 
             //Check if the object already be created
             if (isset($config["cache"][$cacheConfig])) {


### PR DESCRIPTION
Helper get the config with a wrong path. Instead use default from Cache, I send 'application' as first parameter.
@arroyo 
